### PR TITLE
Remove everything from the cache dir, including hidden dirs.

### DIFF
--- a/lib/heroku/command/repo.rb
+++ b/lib/heroku/command/repo.rb
@@ -15,7 +15,8 @@ cd tmp/repo_tmp
 curl -o repo.tgz '#{repo_get_url}'
 cd unpack
 tar -zxf ../repo.tgz
-rm -rf .cache/*
+rm -rf .cache
+mkdir .cache
 tar -zcf ../repack.tgz .
 curl -o /dev/null --upload-file ../repack.tgz '#{repo_put_url}'
 exit


### PR DESCRIPTION
The `rm -rf .cache/*` misses hidden dirs. Removing the `.cache` dir and replacing it fixes that.
