### PR TITLE
Delete cache object

### DIFF
--- a/lib/heroku/command/repo.rb
+++ b/lib/heroku/command/repo.rb
@@ -18,6 +18,7 @@ tar -zxf ../repo.tgz
 rm -rf .cache/*
 tar -zcf ../repack.tgz .
 curl -o /dev/null --upload-file ../repack.tgz '#{repo_put_url}'
+curl --request DELETE '#{cache_delete_url}'
 exit
 EOF
   end


### PR DESCRIPTION
We're introducing a change to how we store the cache. This means that it's necessary to purge the cache in both locations. I'll make a second pull request once the original method is made obsolute.
