### PR TITLE
Remove Rebuild Command

### DIFF
--- a/lib/heroku/command/repo.rb
+++ b/lib/heroku/command/repo.rb
@@ -96,14 +96,6 @@ exit
 EOF
   end
 
-  # repo:rebuild
-  #
-  # Force a rebuild of the master branch
-  def rebuild
-    reset
-    system "git push #{extract_app_from_git_config || "heroku"} master"
-  end
-
   private
 
   def cache_delete_url


### PR DESCRIPTION
Rebuilding this way can cause conflicts. It's better to use the Build
API for `rebuild`.