### PR TITLE
Switch to api.request which supports 2fa

### DIFF
--- a/lib/heroku/command/repo.rb
+++ b/lib/heroku/command/repo.rb
@@ -114,12 +114,12 @@ EOF
   end
 
   def release
-   @release ||= api.request(
+    @release ||= api.request(
       :method  => "get",
       :expects => 200,
       :path    => "/apps/#{app}/releases/new",
       :headers => {
-        "Accept"        => "application/vnd.heroku+json; version=2",
+        "Accept" => "application/vnd.heroku+json; version=2",
       }
     ).body
   end


### PR DESCRIPTION
The plugin is using the legacy `heroku.get` which is not fitted for prompting for a two-factor code when required. This change switches to the newer `api.request` method, which does support 2fa.

_Note_: Moved the `repo_get_url` call in `clone` before any fs side effects, as the 2fa code retries the method and causes double nesting of directories, `app/.git/app/.git`.

Fixes #24.
