### PR TITLE
Add command to download cache content

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ This will run a `git gc --agressive` against the applications repo. This is done
 
 This will delete the contents of the build cache stored in the repository. This is done inside a run process on the application.
 
+### download_cache
+
+    $ heroku repo:download_cache -a appname
+
+This will download the contents of the build cache as a tarball.
+
 ### reset
 
     $ heroku repo:reset -a appname

--- a/lib/heroku/command/repo.rb
+++ b/lib/heroku/command/repo.rb
@@ -38,6 +38,15 @@ EOF
   end
   alias_command "repo:purge-cache", "repo:purge_cache"
 
+  # repo:download-cache
+  #
+  # Download the build cache for debugging
+  def download_cache
+    puts cache_get_url
+    system("curl -o #{app}-repo.tgz '#{cache_get_url}'")
+  end
+  alias_command "repo:download-cache", "repo:download_cache"
+
   # repo:gc
   #
   # Run a git gc --agressive on the applications repository

--- a/lib/heroku/command/repo.rb
+++ b/lib/heroku/command/repo.rb
@@ -43,7 +43,7 @@ EOF
   # Download the build cache for debugging
   def download_cache
     puts cache_get_url
-    system("curl -o #{app}-repo.tgz '#{cache_get_url}'")
+    system("curl -o #{app}-cache.tgz '#{cache_get_url}'")
   end
   alias_command "repo:download-cache", "repo:download_cache"
 


### PR DESCRIPTION
I've recently run into an issue where a gem I created didn't work well with the build cache - adding a way to download the cache content from Heroku helped me debug this.

This adds a `repo:download-cache` command to the plugin, the cache gets saved as `#{app}-repo.tgz`.

Thought it might be helpful for others :)