### PR TITLE
Use v3 of the API instead of v2

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -4,8 +4,8 @@ const cli = require('heroku-cli-util')
 
 function getRelease (app) {
   return cli.heroku.request({
-    path: `/apps/${app}/releases/new`,
-    headers: {Accept: 'application/vnd.heroku+json; version=2'}
+    path: `/apps/${app}/build-metadata`,
+    headers: {Accept: 'application/vnd.heroku+json; version=3.build-metadata'}
   })
 }
 


### PR DESCRIPTION
V2 is deprecated and will be removed soon.

cc @heroku/build 