### PR TITLE
Deprecate the purge_cache command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This will run a `git gc --aggressive` against the applications repo. This is don
 
 This will delete the contents of the build cache stored in the repository. This is done inside a run process on the application.
 
+**WARNING: This command deprecated in favor of the `builds:cache:purge` command in the [heroku-builds](https://github.com/heroku/heroku-builds) plugin**
+
 ### reset
 
     $ heroku repo:reset -a appname

--- a/commands/purge_cache.js
+++ b/commands/purge_cache.js
@@ -5,6 +5,8 @@ const co = require('co')
 const {Dyno} = require('heroku-run')
 
 function * run (context) {
+  cli.warn(`WARNING: This command is deprecated in favor of 'builds:cache:purge' in the heroku-builds plugin`)
+
   const repo = require('../lib/repo')
   const app = context.app
 


### PR DESCRIPTION
In favor of builds:cache:purge, using built-in functionality