### PR TITLE
De-deprecate this command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ This will run a `git gc --aggressive` against the applications repo. This is don
 
 This will delete the contents of the build cache stored in the repository. This is done inside a run process on the application.
 
-**WARNING: This command deprecated in favor of the `builds:cache:purge` command in the [heroku-builds](https://github.com/heroku/heroku-builds) plugin**
-
 ### reset
 
     $ heroku repo:reset -a appname

--- a/commands/purge_cache.js
+++ b/commands/purge_cache.js
@@ -5,8 +5,6 @@ const co = require('co')
 const {Dyno} = require('heroku-run')
 
 function * run (context) {
-  cli.warn(`WARNING: This command is deprecated in favor of 'builds:cache:purge' in the heroku-builds plugin`)
-
   const repo = require('../lib/repo')
   const app = context.app
 


### PR DESCRIPTION
Per discussion in #build, the `heroku builds:cache:purge` command _does not_ have equivalent behaviour. Until we find something that works for users of that command, we'll hold off on deprecating this command.

This reverts commit 3742be3a18a50864cf550b836d3f3904074ccc24, reversing
changes made to dbd6fc9e6fe6893958c359297b7a1652e4147d47.