### PR TITLE
Fix command descriptions

### DIFF
--- a/commands/clone.js
+++ b/commands/clone.js
@@ -30,7 +30,7 @@ function * run (context) {
 module.exports = {
   topic: 'repo',
   command: 'clone',
-  description: 'sets the bare repo for immediate consumption',
+  description: 'set the bare repo for immediate consumption',
   needsAuth: true,
   needsApp: true,
   run: cli.command(co.wrap(run))

--- a/commands/purge_cache.js
+++ b/commands/purge_cache.js
@@ -44,7 +44,7 @@ exit`
 module.exports = {
   topic: 'repo',
   command: 'purge_cache',
-  description: 'deletes the contents the build cache in the repository',
+  description: 'delete the contents of the build cache in the repository',
   needsAuth: true,
   needsApp: true,
   run: cli.command(co.wrap(run))


### PR DESCRIPTION
The description of `purge_cache` was missing the word "of". Also the different tasks didn't consistently use the same grammatical person (i.e. "set" vs "sets") so I changed everything to the more common style.