### PR TITLE
Allow for easy build cache downloads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,11 @@
+version: 2.1
+orbs:
+  # Declare a dependency on the welcome-orb
+  welcome: circleci/welcome-orb@0.4.1
+# Orchestrate or schedule a set of jobs
+workflows:
+  # Name the workflow "welcome"
+  welcome:
+    # Run the welcome/run job in its own container
+    jobs:
+      - welcome/run

--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ This will download the applications repo as a tarball.
 
 This will run a `git gc --aggressive` against the applications repo. This is done inside a run process on the application.
 
-### purge-cache
+### download_cache
+
+    $ heroku repo:download_cache -a appname
+
+This command downloads the build cache for a given application so you can inspect it locally.
+
+### purge_cache
 
     $ heroku repo:purge_cache -a appname
 
@@ -39,3 +45,12 @@ This will delete the contents of the build cache stored in the repository. This 
     $ heroku repo:reset -a appname
 
 This will empty the remote repository.
+
+
+## Local development
+
+To develop this CLI plugin, clone this repo then run:
+
+```
+$ heroku plugins:link ./
+```

--- a/commands/download_cache.js
+++ b/commands/download_cache.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+const co = require('co')
+const {Dyno} = require('@heroku-cli/plugin-run')
+
+function * run (context) {
+  const repo = require('../lib/repo')
+  const download = require('../lib/download')
+  const app = context.app
+
+  console.log("This command is experimental and subject to change, use as your own risk")
+
+  // console.log(yield)
+  let filename = context.args.filename || `${app}-cache.tgz`
+
+  yield download(yield repo.getCacheURL(app), filename, {progress: true})
+}
+
+module.exports = {
+  topic: 'repo',
+  command: 'download_cache',
+  description: 'downloads the contents of an application build cache for local inspection [EXPERIMENTAL]',
+  needsAuth: true,
+  needsApp: true,
+  run: cli.command(co.wrap(run))
+}

--- a/index.js
+++ b/index.js
@@ -10,5 +10,6 @@ exports.commands = [
   require('./commands/download'),
   require('./commands/gc'),
   require('./commands/purge_cache'),
+  require('./commands/download_cache'),
   require('./commands/reset')
 ]


### PR DESCRIPTION
```
$ heroku repo:download_cache -a issuetriage
heroku: linking plugin heroku-repo... done
Downloading... ████████████████████████▏  100% 00:00 72.23MB
```

```
$ ls | grep cache
issuetriage-cache.tgz
```