### PR TITLE
fix: bump heroku-cli-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@heroku-cli/plugin-run": "3.8.10",
     "bytes": "3.0.0",
     "co": "4.6.0",
-    "heroku-cli-util": "8.0.10",
+    "heroku-cli-util": "8.0.12",
     "mkdirp": "0.5.1",
     "smooth-progress": "1.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,7 +933,28 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.1.1"
 
-heroku-cli-util@8.0.10, heroku-cli-util@^8.0.9:
+heroku-cli-util@8.0.12:
+  version "8.0.12"
+  resolved "https://registry.yarnpkg.com/heroku-cli-util/-/heroku-cli-util-8.0.12.tgz#a2a13126095887c16afc01e3ac0f7816ddbe2a05"
+  integrity sha512-63wB17oSktlA/HzpIV/PGe8Isq5AZArT51KAW1gg54zyYRIiHOwXik93HZuuRVUaVrWvVUhItFeLgqMwAwlTsw==
+  dependencies:
+    "@heroku-cli/color" "^1.1.3"
+    ansi-escapes "^3.1.0"
+    ansi-styles "^3.2.1"
+    cardinal "^2.0.1"
+    chalk "^2.4.1"
+    co "^4.6.0"
+    got "^8.3.1"
+    heroku-client "^3.1.0"
+    lodash "^4.17.10"
+    netrc-parser "^3.1.4"
+    opn "^3.0.3"
+    strip-ansi "^4.0.0"
+    supports-color "^5.4.0"
+    tslib "^1.9.0"
+    tunnel-agent "^0.6.0"
+
+heroku-cli-util@^8.0.9:
   version "8.0.10"
   resolved "https://registry.yarnpkg.com/heroku-cli-util/-/heroku-cli-util-8.0.10.tgz#c14aa0ac8c31ddd5c18aac73369332b42c4205fc"
   integrity sha512-NMcdnX3y2N+efhRGeZvBokmBtDdggtrgRb3pozhyrR2+5LmzKkDLONK/MfjvwrpAUP2MXPu8UkxJDnM/SAGlxA==
@@ -958,6 +979,14 @@ heroku-client@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/heroku-client/-/heroku-client-3.0.6.tgz#bf603716a9d469682d4f7f80489276d82b896305"
   integrity sha512-1FKLb5ngGTMwUh67DPiYmv+TaKasTfZSYHno/Kx0goE6Fqutec3WILCHPmOfw9LTGnRjL9/Pmi5BNmu9GwNFNA==
+  dependencies:
+    is-retry-allowed "^1.0.0"
+    tunnel-agent "^0.6.0"
+
+heroku-client@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/heroku-client/-/heroku-client-3.1.0.tgz#7e3f6804d18a6ee9e3a774ff8bc9861b9b1a4725"
+  integrity sha512-UfGKwUm5duzzSVI8uUXlNAE1mus6uPxmZPji4vuG1ArV5DYL1rXsZShp0OoxraWdEwYoxCUrM6KGztC68x5EZQ==
   dependencies:
     is-retry-allowed "^1.0.0"
     tunnel-agent "^0.6.0"


### PR DESCRIPTION
This should fix the downstream header deprecation warning:
`DeprecationWarning: OutgoingMessage.prototype._headers is deprecated`

This was fixed in heroku-cli-util:
https://github.com/heroku/heroku-cli-util/pull/127