### PR TITLE
Add -s flag to specify dyno size for gc and purge_cache commands

### DIFF
--- a/commands/gc.js
+++ b/commands/gc.js
@@ -7,10 +7,12 @@ const {Dyno} = require('@heroku-cli/plugin-run')
 function * run (context) {
   const repo = require('../lib/repo')
   const app = context.app
+  const size = context.flags.size
 
   let dyno = new Dyno({
     heroku: cli.heroku,
     app,
+    size,
     attach: true,
     command: `set -e
 mkdir -p tmp/repo_tmp/unpack
@@ -32,5 +34,8 @@ module.exports = {
   description: "run a git gc --aggressive on an application's repository",
   needsAuth: true,
   needsApp: true,
+  flags: [
+    { name: 'size', char: 's', description: 'dyno size', hasValue: true }
+  ],
   run: cli.command(co.wrap(run))
 }

--- a/commands/purge_cache.js
+++ b/commands/purge_cache.js
@@ -7,10 +7,12 @@ const {Dyno} = require('@heroku-cli/plugin-run')
 function * run (context) {
   const repo = require('../lib/repo')
   const app = context.app
+  const size = context.flags.size
 
   let dyno = new Dyno({
     heroku: cli.heroku,
     app,
+    size,
     attach: true,
     command: `set -e
 mkdir -p tmp/repo_tmp/unpack
@@ -47,5 +49,8 @@ module.exports = {
   description: 'delete the contents of the build cache in the repository',
   needsAuth: true,
   needsApp: true,
+  flags: [
+    { name: 'size', char: 's', description: 'dyno size', hasValue: true }
+  ],
   run: cli.command(co.wrap(run))
 }


### PR DESCRIPTION
When running `repo:gc` command I kept getting R14 (Memory quota exceeded) errors.
So I added support to for the `-s` flag to specify a dyno size in the event you need something bigger than the default 1X.