### PR TITLE
Use absolute file names when extracting the tar

### DIFF
--- a/commands/purge_cache.js
+++ b/commands/purge_cache.js
@@ -17,7 +17,7 @@ mkdir -p tmp/repo_tmp/unpack
 cd tmp/repo_tmp
 curl -fo repo-cache.tgz '${yield repo.getCacheURL(app)}'
 cd unpack
-tar -zxf ../repo-cache.tgz
+tar -zxPf ../repo-cache.tgz
 METADATA="vendor/heroku"
 if [ -d "$METADATA" ]; then
   TMPDIR=\`mktemp -d\`


### PR DESCRIPTION
When trying to run the `repo:purge_cache` command it kept failing with the following errors:

```
tar: ./heroku-16/vendor/bundle/ruby: Directory renamed before its status could be extracted
tar: ./heroku-16/vendor/bundle: Directory renamed before its status could be extracted
tar: ./heroku-16/vendor: Directory renamed before its status could be extracted
tar: ./heroku-16: Directory renamed before its status could be extracted
tar: Exiting with failure status due to previous errors
```

I think something in our existing slug was using relative paths (`../`) which was causing the tar to fail. The tar is extracted successfully if we simply add the `--absolute-names` (`-P`) flag [1]

[1]: https://www.gnu.org/software/tar/manual/html_node/absolute.html