### PR TITLE
chore: ignoring workflows-repo when linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ export default [
       './dist',
       './lib',
       '**/*.js',
+      './workflows-repo',
     ],
   },
   {


### PR DESCRIPTION
## Summary

This adds the `worflows-repo` folder to the ignored folders for linting because it's causing the release action to fail.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [X] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

**Steps**:
Passing CI suffices.

## Related Issues
[Release Action failure](https://github.com/heroku/heroku-repo/actions/runs/25326389459/job/74248222075#step:5:392)