### PR TITLE
fix: avoid extracting unrelated build cache contents during purge

### DIFF
--- a/src/commands/repo/purge-cache.ts
+++ b/src/commands/repo/purge-cache.ts
@@ -22,22 +22,16 @@ mkdir -p tmp/repo_tmp/unpack
 cd tmp/repo_tmp
 curl -fo repo-cache.tgz '${repoGetCacheURL}'
 cd unpack
-tar -zxf ../repo-cache.tgz
-METADATA="vendor/heroku"
-if [ -d "$METADATA" ]; then
-  TMPDIR=\`mktemp -d\`
-  cp -rf $METADATA $TMPDIR
+METADATA=
+if tar -tzf ../repo-cache.tgz ./vendor/heroku >/dev/null 2>&1; then
+  METADATA=./vendor/heroku
+elif tar -tzf ../repo-cache.tgz vendor/heroku >/dev/null 2>&1; then
+  METADATA=vendor/heroku
+else
+  tar -tzf ../repo-cache.tgz >/dev/null
 fi
-cd ..
-rm -rf unpack
-mkdir unpack
-cd unpack
-TMPDATA="$TMPDIR/heroku"
-VENDOR="vendor"
-if [ -d "$TMPDATA" ]; then
-  mkdir $VENDOR
-  cp -rf $TMPDATA $VENDOR
-  rm -rf $TMPDIR
+if [ -n "$METADATA" ]; then
+  tar -zxf ../repo-cache.tgz "$METADATA"
 fi
 tar -zcf ../cache-repack.tgz .
 curl -fo /dev/null --upload-file ../cache-repack.tgz '${repoPutCacheURL}'

--- a/test/commands/repo/purge-cache.test.ts
+++ b/test/commands/repo/purge-cache.test.ts
@@ -29,22 +29,16 @@ mkdir -p tmp/repo_tmp/unpack
 cd tmp/repo_tmp
 curl -fo repo-cache.tgz 'https://get-cache-url.com'
 cd unpack
-tar -zxf ../repo-cache.tgz
-METADATA="vendor/heroku"
-if [ -d "$METADATA" ]; then
-  TMPDIR=\`mktemp -d\`
-  cp -rf $METADATA $TMPDIR
+METADATA=
+if tar -tzf ../repo-cache.tgz ./vendor/heroku >/dev/null 2>&1; then
+  METADATA=./vendor/heroku
+elif tar -tzf ../repo-cache.tgz vendor/heroku >/dev/null 2>&1; then
+  METADATA=vendor/heroku
+else
+  tar -tzf ../repo-cache.tgz >/dev/null
 fi
-cd ..
-rm -rf unpack
-mkdir unpack
-cd unpack
-TMPDATA="$TMPDIR/heroku"
-VENDOR="vendor"
-if [ -d "$TMPDATA" ]; then
-  mkdir $VENDOR
-  cp -rf $TMPDATA $VENDOR
-  rm -rf $TMPDIR
+if [ -n "$METADATA" ]; then
+  tar -zxf ../repo-cache.tgz "$METADATA"
 fi
 tar -zcf ../cache-repack.tgz .
 curl -fo /dev/null --upload-file ../cache-repack.tgz 'https://put-cache-url.com'
@@ -77,5 +71,10 @@ describe('repo:purge-cache', () => {
     expect(dynoOpts.app).to.equal('myapp')
     expect(dynoOpts.attach).to.equal(true)
     expect(dynoOpts.command).to.equal(commandString)
+    expect(dynoOpts.command).toContain('tar -zxf ../repo-cache.tgz "$METADATA"')
+    expect(dynoOpts.command).not.toContain('tar -zxf ../repo-cache.tgz\n')
+    expect(dynoOpts.command).not.toContain('mktemp')
+    expect(dynoOpts.command).not.toContain('cp -rf')
+    expect(dynoOpts.command).not.toContain('rm -rf unpack')
   })
 })


### PR DESCRIPTION
## Summary

Change the dyno shell command in `src/commands/repo/purge-cache.ts` to extract only the `vendor/heroku` metadata subtree from the downloaded archive into the clean repack directory, rather than extracting the whole archive and copying the metadata through a temporary directory. Keep the current behavior of producing and uploading an otherwise empty cache archive when that subtree is absent, and retain `set -e` so genuine download, extraction, packaging, or upload failures still propagate. Update the existing command-construction test to lock down the selective extraction flow and prove that no full-archive extraction or temporary metadata copy remains.

`repo:purge-cache` downloads and extracts the complete build-cache archive before discarding everything except `vendor/heroku`. Some archives fail during that full extraction with GNU tar's "Directory renamed before its status could be extracted" error in unrelated Node cache paths, so the command exits before it can upload the purged cache. The command must continue preserving `vendor/heroku`, as explained in the maintainer's workaround comment, while avoiding traversal of cache content that will be discarded.

Fixes #103

## Type of Change

Not applicable to this change.

### Breaking Changes (major semver update)

- [x] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)

- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)

- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [x] **test**: Add/update/remove tests

## Testing

**Notes**: 


**Steps**:
1. Replace this text with a list of steps used to validate changes or type 'Passing CI suffices'.
2. ...

## Screenshots (if applicable)



## Related Issues

GitHub issue: #[GitHub issue number]
GUS work item: [WI number](WI link)
